### PR TITLE
Use built-in coverage in Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:watch": "jest --watch",
     "precover": "rimraf coverage && mkdir -p ./coverage/",
     "cover": "NODE_ENV=test node --max-old-space-size=2048 $(which nyc) npm run test:jest",
-    "coveralls": "nyc npm run test:jest && nyc report --reporter=text-lcov | coveralls",
+    "coveralls": "jest --coverage && cat ./coverage/lcov.info | coveralls",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "tag": "git tag v$npm_package_version",
     "version:patch": "npm --no-git-tag-version version patch",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint:fix": "eslint src test --fix",
     "test": "npm run lint && npm run test:jest",
     "test:jest": "jest",
+    "test:coverage": "jest --coverage",
     "test:nocache": "jest --no-cache",
     "test:watch": "jest --watch",
     "precover": "rimraf coverage && mkdir -p ./coverage/",


### PR DESCRIPTION
Jest has an excellent and easy to use code coverage feature. Why not just use that?
Added new command for test coverage with jest: `test:coverage`

![coverage-timezone](https://user-images.githubusercontent.com/5586960/31095980-ed1078a2-a7ba-11e7-9f44-8b35a70f0989.png)
